### PR TITLE
Updated Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: java
+env:
+  - MAVEN_VERSION=3.0.5
+  - MAVEN_VERSION=3.3.9
+  - MAVEN_VERSION=3.5.2
 jdk:
-  - openjdk6
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
-# We don't need an install before
-# we run the unit and integration tests.
-install: true
-script: "mvn --show-version --errors --batch-mode -Prun-its clean verify"
+install:
+  - "mvn -N io.takari:maven:wrapper -Dmaven=${MAVEN_VERSION}"
+  - "./mvnw --show-version --errors --batch-mode validate dependency:go-offline"
+script: "./mvnw --show-version --errors --batch-mode -Prun-its clean verify"
 cache:
     directories:
     - $HOME/.m2


### PR DESCRIPTION
 o removed openjdk6 as not supported out-of-the-box on Travis Trusty image
 o changed oraclejdk7 to openjdk7 to solve issue with JAVA_HOME not set on Travis Trusty image
 o now builds with Maven 3.0.5, 3.3.9, and 3.5.2