### PR TITLE
Fix GitHub ribbon on website

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,4 +1,11 @@
 <project xmlns="http://maven.apache.org/DECORATION/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+  <custom>
+    <fluidoSkin>
+      <gitHub>
+        <projectId>mojohaus/${project.artifactId}</projectId>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
   <body>
     <menu name="Overview">
       <item name="Introduction" href="index.html"/>


### PR DESCRIPTION
Currently the ribbon on the website (http://www.mojohaus.org/tidy-maven-plugin/) always links to the mojo-parent GitHub project.

Details can be found here
* how GitHub ribbons are to be configured - https://maven.apache.org/skins/maven-fluido-skin/
* site.xml in the parent pom where everything is defined - https://github.com/mojohaus/mojo-parent/blob/master/src/site/site.xml
* pull request in the parent pom to fix it for all projects - https://github.com/mojohaus/mojo-parent/pull/68