### PR TITLE
Make testing with Java 7 possible again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
   - openjdk7
   - oraclejdk8
 install:
-  - "mvn -N io.takari:maven:wrapper -Dmaven=${MAVEN_VERSION}"
+  - "mvn -N io.takari:maven:0.4.0:wrapper -Dmaven=${MAVEN_VERSION}"
   - "./mvnw --show-version --errors --batch-mode validate dependency:go-offline"
 script: "./mvnw --show-version --errors --batch-mode -Prun-its clean verify"
 cache:


### PR DESCRIPTION
Since Takari Maven plugin v0.4.1 only Java 8 is supported.

A better idea would be to even drop Java 7 testing as it is end of life since April 2015.