### PR TITLE
Make check mojo thread-safe:

### DIFF
--- a/src/main/java/org/codehaus/mojo/tidy/CheckMojo.java
+++ b/src/main/java/org/codehaus/mojo/tidy/CheckMojo.java
@@ -28,7 +28,7 @@ import org.apache.maven.plugins.annotations.Mojo;
  * Checks that the <code>pom.xml</code> is tidy. Fails the build if <code>mvn tidy:pom</code> would
  * create a different <code>pom.xml</code> than the current one.
  */
-@Mojo( name = "check", defaultPhase = LifecyclePhase.VERIFY )
+@Mojo( name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class CheckMojo
     extends TidyMojo
 {

--- a/src/main/java/org/codehaus/mojo/tidy/TidyMojo.java
+++ b/src/main/java/org/codehaus/mojo/tidy/TidyMojo.java
@@ -66,6 +66,7 @@ public abstract class TidyMojo
     protected abstract void executeForPom( String pom )
         throws MojoExecutionException, MojoFailureException;
 
+    @Override
     public void execute()
         throws MojoExecutionException, MojoFailureException
     {


### PR DESCRIPTION
This mojo operates on the POM file of the current module only, hence
other modules that might being built in parallel, cannot affect it.

Also add missing `@Override` annotation.

Resolves #27