### PR TITLE
Fix Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: java
 env:
-  - MAVEN_VERSION=3.0.5
   - MAVEN_VERSION=3.3.9
-  - MAVEN_VERSION=3.5.2
+  - MAVEN_VERSION=3.5.4
+  - MAVEN_VERSION=3.6.3
 jdk:
-  - openjdk7
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 install:
-  - "mvn -N io.takari:maven:0.4.0:wrapper -Dmaven=${MAVEN_VERSION}"
+  - "mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=${MAVEN_VERSION}"
   - "./mvnw --show-version --errors --batch-mode validate dependency:go-offline"
 script: "./mvnw --show-version --errors --batch-mode -Prun-its clean verify"
 cache:


### PR DESCRIPTION
"openjdk7" and "oraclejdk8" are not supported without further modifications on Travis anymore, therefore replacing them with OpenJDK 8 and 11.
    
Removing tests for Maven 3.0.5 as it connects to Maven Central via HTTP which is not supported anymore as of 2020-01-15, see https://links.sonatype.com/central/501-https-required.
    
Additionally using the latest Maven version and upgrading the Maven wrapper.