### PR TITLE
Fix provided dependencies scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,11 +121,13 @@
       <artifactId>maven-plugin-api</artifactId>
       <!-- Overriding version in mojo-parent for Maven 2.2.1 compatibility -->
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
Avoid:
```
[INFO] --- maven-plugin-plugin:3.6.4:helpmojo (help-mojo) @ tidy-maven-plugin --- [ERROR]

Some dependencies of Maven Plugins are expected to be in provided scope. Please make sure that dependencies listed below declared in POM have set '<scope>provided</scope>' as well.

The following dependencies are in wrong scope:
 * org.apache.maven:maven-plugin-api:jar:2.2.1:compile
 * org.apache.maven:maven-project:jar:2.2.1:compile
 * org.apache.maven:maven-settings:jar:2.2.1:compile
 * org.apache.maven:maven-profile:jar:2.2.1:compile
 * org.apache.maven:maven-model:jar:2.2.1:compile
 * org.apache.maven:maven-artifact-manager:jar:2.2.1:compile
 * org.apache.maven:maven-repository-metadata:jar:2.2.1:compile
 * org.apache.maven:maven-plugin-registry:jar:2.2.1:compile
 * org.apache.maven:maven-artifact:jar:2.2.1:compile
```

