### PR TITLE
Add support for `pomFile` parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>tidy-maven-plugin</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Tidy Maven Plugin</name>

--- a/src/it/check-separate-fails/invalid-pom.xml
+++ b/src/it/check-separate-fails/invalid-pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <artifactId>pom-check-fails</artifactId>
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <parent>
+    <groupId>org.codehaus</groupId>
+    <artifactId>codehaus-parent</artifactId>
+    <version>4</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test that check fails for a POM that is not tidy.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>tidy-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-separate-fails/invalid-pom.xml
+++ b/src/it/check-separate-fails/invalid-pom.xml
@@ -12,23 +12,4 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>Test that check fails for a POM that is not tidy.</description>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tidy-maven-plugin</artifactId>
-        <version>@pom.version@</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/src/it/check-separate-fails/invoker.properties
+++ b/src/it/check-separate-fails/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = verify
+invoker.buildResult = failure

--- a/src/it/check-separate-fails/pom.xml
+++ b/src/it/check-separate-fails/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus</groupId>
+    <artifactId>codehaus-parent</artifactId>
+    <version>4</version>
+  </parent>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>pom-check-separate-fails</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test that check fails for an external invalid POM</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>tidy-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <pomFile>${project.basedir}/invalid-pom.xml</pomFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-separate-succeeds/invoker.properties
+++ b/src/it/check-separate-succeeds/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = verify
+invoker.buildResult = success 

--- a/src/it/check-separate-succeeds/pom.xml
+++ b/src/it/check-separate-succeeds/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <artifactId>pom-check-fails</artifactId>
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <parent>
+    <groupId>org.codehaus</groupId>
+    <artifactId>codehaus-parent</artifactId>
+    <version>4</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test that check passes for a separate POM that is tidy.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>tidy-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <pomFile>${project.basedir}/valid-pom.xml</pomFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-separate-succeeds/valid-pom.xml
+++ b/src/it/check-separate-succeeds/valid-pom.xml
@@ -13,23 +13,4 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>Test that check doesn't fail for a tidy separate POM</description>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tidy-maven-plugin</artifactId>
-        <version>@pom.version@</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/src/it/check-separate-succeeds/valid-pom.xml
+++ b/src/it/check-separate-succeeds/valid-pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus</groupId>
+    <artifactId>codehaus-parent</artifactId>
+    <version>4</version>
+  </parent>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>pom-check-succeeds</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test that check doesn't fail for a tidy separate POM</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>tidy-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/separate-pom/invoker.properties
+++ b/src/it/separate-pom/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = org.codehaus.mojo:tidy-maven-plugin:${project.version}:pom -Dtidy.pomFile=separate-pom.xml
+invoker.buildResult = success 

--- a/src/it/separate-pom/pom.xml
+++ b/src/it/separate-pom/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <packaging>pom</packaging>
+
+  <artifactId>pom-space-indent</artifactId>
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <parent>
+    <groupId>org.codehaus</groupId>
+    <artifactId>codehaus-parent</artifactId>
+    <version>4</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <version>1.0-SNAPSHOT</version>
+  <description>Test of tidy:pom on a separate pom with all elements.</description>
+
+</project>

--- a/src/it/separate-pom/separate-pom-expected.xml
+++ b/src/it/separate-pom/separate-pom-expected.xml
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus</groupId>
+    <artifactId>codehaus-parent</artifactId>
+    <version>4</version>
+  </parent>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>pom-space-indent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Complete POM test</name>
+  <description>Test of tidy:pom on a separate pom with all elements.</description>
+  <url>http://maven.apache.org</url>
+  <inceptionYear>2011</inceptionYear>
+  <organization>
+    <name>MojoHaus</name>
+    <url>http://www.mojohaus.org</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>John Doe</name>
+      <email>john.doe@acme.org</email>
+      <roles>
+        <role>Lead Developer</role>
+      </roles>
+      <timezone>0</timezone>
+    </developer>
+  </developers>
+  <contributors>
+    <contributor>
+      <name>Jane Doe</name>
+      <email>jone.doe@acme.org</email>
+    </contributor>
+  </contributors>
+
+  <mailingLists>
+    <mailingList>
+      <name>MojoHaus Development List</name>
+      <subscribe>mojohaus-dev+subscribe@googlegroups.com</subscribe>
+      <unsubscribe>mojohaus-dev+unsubscribe@googlegroups.com</unsubscribe>
+      <post>mojohaus-dev@googlegroups.com</post>
+      <archive>https://groups.google.com/forum/#!forum/mojohaus-dev</archive>
+    </mailingList>
+    <mailingList>
+      <name>Maven Users List</name>
+      <subscribe>users-subscribe@maven.apache.org</subscribe>
+      <unsubscribe>users-unsubscribe@maven.apache.org</unsubscribe>
+      <post>users@maven.apache.org</post>
+      <archive>http://mail-archives.apache.org/mod_mbox/maven-users/</archive>
+      <otherArchives>
+        <otherArchive>http://maven.40175.n5.nabble.com/Maven-Users-f40176.html</otherArchive>
+      </otherArchives>
+    </mailingList>
+  </mailingLists>
+
+  <prerequisites>
+    <maven>2.2.1</maven>
+  </prerequisites>
+
+  <scm>
+    <connection>scm:git:https://github.com/mojohaus/tidy-maven-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/mojohaus/tidy-maven-plugin.git</developerConnection>
+    <url>https://github.com/mojohaus/tidy-maven-plugin</url>
+  </scm>
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/mojohaus/tidy-maven-plugin/issues</url>
+  </issueManagement>
+  <ciManagement>
+    <system>travis</system>
+    <url>https://travis-ci.org/mojohaus/tidy-maven-plugin</url>
+  </ciManagement>
+  <distributionManagement>
+    <repository>
+      <id>ossrh-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </repository>
+    <snapshotRepository>
+      <id>ossrh-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <site>
+      <id>github</id>
+      <url>scm:git:git@github.com:mojohaus/tidy-maven-plugin.git</url>
+    </site>
+  </distributionManagement>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit.version>5.7.2</junit.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.0.24</version>
+        <type>jar</type>
+        <scope>compile</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.19.0</version>
+      <type>bundle</type>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>ossrh-snapshots</id>
+      <name>ossrh-snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>ossrh-snapshots</id>
+      <name>ossrh-snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.5.1</version>
+          <configuration></configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.16</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <id>build-helper</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <source>dummy</source>
+        </configuration>
+      </plugin>
+    </plugins>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh-external</artifactId>
+        <version>1.0-beta-6</version>
+      </extension>
+    </extensions>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.7</version>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <profiles>
+    <profile>
+      <id>run-its</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+          <value>!true</value>
+        </property>
+      </activation>
+    </profile>
+  </profiles>
+</project>

--- a/src/it/separate-pom/separate-pom.xml
+++ b/src/it/separate-pom/separate-pom.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <packaging>pom</packaging>
+
+  <artifactId>pom-space-indent</artifactId>
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <parent>
+    <groupId>org.codehaus</groupId>
+    <artifactId>codehaus-parent</artifactId>
+    <version>4</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <version>1.0-SNAPSHOT</version>
+  <description>Test of tidy:pom on a separate pom with all elements.</description>
+  
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <name>Complete POM test</name>
+  <inceptionYear>2011</inceptionYear>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit.version>5.7.2</junit.version>
+  </properties>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>ossrh-snapshots</id>
+      <name>ossrh-snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+  <organization>
+    <name>MojoHaus</name>
+    <url>http://www.mojohaus.org</url>
+  </organization>
+
+  <repositories>
+    <repository>
+      <id>ossrh-snapshots</id>
+      <name>ossrh-snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+
+  <mailingLists>
+    <mailingList>
+      <name>MojoHaus Development List</name>
+      <subscribe>mojohaus-dev+subscribe@googlegroups.com</subscribe>
+      <unsubscribe>mojohaus-dev+unsubscribe@googlegroups.com</unsubscribe>
+      <post>mojohaus-dev@googlegroups.com</post>
+      <archive>https://groups.google.com/forum/#!forum/mojohaus-dev</archive>
+    </mailingList>
+    <mailingList>
+      <name>Maven Users List</name>
+      <subscribe>users-subscribe@maven.apache.org</subscribe>
+      <unsubscribe>users-unsubscribe@maven.apache.org</unsubscribe>
+      <post>users@maven.apache.org</post>
+      <archive>http://mail-archives.apache.org/mod_mbox/maven-users/</archive>
+      <otherArchives>
+        <otherArchive>http://maven.40175.n5.nabble.com/Maven-Users-f40176.html</otherArchive>
+      </otherArchives>
+    </mailingList>
+  </mailingLists>
+  <scm>
+    <connection>scm:git:https://github.com/mojohaus/tidy-maven-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/mojohaus/tidy-maven-plugin.git</developerConnection>
+    <url>https://github.com/mojohaus/tidy-maven-plugin</url>
+  </scm>
+
+  <prerequisites>
+    <maven>2.2.1</maven>
+  </prerequisites>
+
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/mojohaus/tidy-maven-plugin/issues</url>
+  </issueManagement>
+  <contributors>
+    <contributor>
+      <name>Jane Doe</name>
+      <email>jone.doe@acme.org</email>
+    </contributor>
+  </contributors>
+  <developers>
+    <developer>
+      <name>John Doe</name>
+      <email>john.doe@acme.org</email>
+      <roles>
+        <role>Lead Developer</role>
+      </roles>
+      <timezone>0</timezone>
+    </developer>
+  </developers>
+
+  <distributionManagement>
+    <repository>
+      <id>ossrh-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </repository>
+    <snapshotRepository>
+      <id>ossrh-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <site>
+      <id>github</id>
+      <url>scm:git:git@github.com:mojohaus/tidy-maven-plugin.git</url>
+    </site>
+  </distributionManagement>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.0.24</version>
+        <type>jar</type>
+        <scope>compile</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh-external</artifactId>
+        <version>1.0-beta-6</version>
+      </extension>
+    </extensions>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.5.1</version>
+          <configuration></configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.16</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <id>build-helper</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <source>dummy</source>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <ciManagement>
+    <system>travis</system>
+    <url>https://travis-ci.org/mojohaus/tidy-maven-plugin</url>
+  </ciManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.19.0</version>
+      <type>bundle</type>
+    </dependency>
+  </dependencies>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.7</version>
+      </plugin>
+    </plugins>
+  </reporting>
+  <profiles>
+    <profile>
+      <id>run-its</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+          <value>!true</value>
+        </property>
+      </activation>
+    </profile>
+  </profiles>
+</project>

--- a/src/it/separate-pom/verify.groovy
+++ b/src/it/separate-pom/verify.groovy
@@ -1,0 +1,4 @@
+File pomFile = new File( basedir, 'separate-pom.xml' )
+File expectedPomFile = new File( basedir, 'separate-pom-expected.xml' )
+
+assert pomFile.getText() == expectedPomFile.getText()

--- a/src/main/java/org/codehaus/mojo/tidy/TidyMojo.java
+++ b/src/main/java/org/codehaus/mojo/tidy/TidyMojo.java
@@ -47,6 +47,16 @@ public abstract class TidyMojo extends AbstractMojo {
     protected MavenProject project;
 
     /**
+     * The path of the pom file to process.
+     *
+     * <p>If unset, the value of <code>project.file</code> will be used instead.</p>
+     * 
+     * @since 1.3.0
+     */
+    @Parameter(property = "tidy.pomFile")
+    private File pomFile;
+
+    /**
      * Set this to 'true' to skip execution.
      */
     @Parameter(property = "tidy.skip", defaultValue = "false")
@@ -88,7 +98,11 @@ public abstract class TidyMojo extends AbstractMojo {
      * Returns the file of the POM.
      */
     protected File getPomFile() {
-        return project.getFile();
+        File result = this.pomFile;
+        if (null == result) {
+            result = this.project.getFile();
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/tidy/TidyMojo.java
+++ b/src/main/java/org/codehaus/mojo/tidy/TidyMojo.java
@@ -50,7 +50,7 @@ public abstract class TidyMojo extends AbstractMojo {
      * The path of the pom file to process.
      *
      * <p>If unset, the value of <code>project.file</code> will be used instead.</p>
-     * 
+     *
      * @since 1.3.0
      */
     @Parameter(property = "tidy.pomFile")

--- a/src/main/java/org/codehaus/mojo/tidy/TidyMojo.java
+++ b/src/main/java/org/codehaus/mojo/tidy/TidyMojo.java
@@ -49,11 +49,9 @@ public abstract class TidyMojo extends AbstractMojo {
     /**
      * The path of the pom file to process.
      *
-     * <p>If unset, the value of <code>project.file</code> will be used instead.</p>
-     *
      * @since 1.3.0
      */
-    @Parameter(property = "tidy.pomFile")
+    @Parameter(property = "tidy.pomFile", defaultValue = "${project.file}")
     private File pomFile;
 
     /**
@@ -98,11 +96,7 @@ public abstract class TidyMojo extends AbstractMojo {
      * Returns the file of the POM.
      */
     protected File getPomFile() {
-        File result = this.pomFile;
-        if (null == result) {
-            result = this.project.getFile();
-        }
-        return result;
+        return this.pomFile;
     }
 
     /**


### PR DESCRIPTION
### Issue

The value of `mavenProject.getFile()` may be referencing a file which has been altered (for example when using the flatten maven plugin) depending on when it's invoked.

The idea of this MR is to allow the explicit specification of the POM file to format (or check) by making it possible to pass a custom value to `pomFile`.

Would allow to fix https://github.com/mojohaus/tidy-maven-plugin/issues/72 (by making it explicit about the pom and not the "potentially altered file")