### PR TITLE
feat: add support for additional project attributes 

### DIFF
--- a/src/main/java/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTag.java
+++ b/src/main/java/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTag.java
@@ -25,6 +25,7 @@ import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.XMLEvent;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -41,22 +42,19 @@ class EnsureSingleLineProjectStartTag implements TidyTask {
     private static final String PROJECT_START_TAG = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" "
             + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
             + "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\"";
-    
-    private static final Collection<QName> PROJECT_4_0_ATTRIBUTES = Collections.singleton(
-        new QName(null, "child.project.url.inherit.append.path")
-    );
-    
-    private static final Collection<QName> PROJECT_4_1_ATTRIBUTES = Collections.unmodifiableSet(
-            new HashSet<>(
-                    Arrays.asList(
-                            new QName(null, "child.project.url.inherit.append.path"),
-                            new QName(null, "root"),
-                            new QName(null, "preserve.model.version")
-                    ))
-    );
-    
-    private static final String PROJECT_4_1_START_TAG = "<project xmlns=\"http://maven.apache.org/POM/4.1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
-            "  xsi:schemaLocation=\"http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd\"";
+
+    private static final Collection<QName> PROJECT_4_0_ATTRIBUTES =
+            Collections.singleton(new QName(null, "child.project.url.inherit.append.path"));
+
+    private static final Collection<QName> PROJECT_4_1_ATTRIBUTES =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+                    new QName(null, "child.project.url.inherit.append.path"),
+                    new QName(null, "root"),
+                    new QName(null, "preserve.model.version"))));
+
+    private static final String PROJECT_4_1_START_TAG =
+            "<project xmlns=\"http://maven.apache.org/POM/4.1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+                    + "  xsi:schemaLocation=\"http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd\"";
 
     @Override
     public String tidyPom(String pom, Format format) throws XMLStreamException {
@@ -134,7 +132,9 @@ class EnsureSingleLineProjectStartTag implements TidyTask {
         return null;
     }
 
-    private String tidyProjectStartTag(String pom, XMLEventReader eventReader, String projectStartTag, Collection<QName> additionalProperties) throws XMLStreamException {
+    private String tidyProjectStartTag(
+            String pom, XMLEventReader eventReader, String projectStartTag, Collection<QName> additionalProperties)
+            throws XMLStreamException {
         while (eventReader.hasNext()) {
             XMLEvent event = eventReader.nextEvent();
             if (event.isStartElement()
@@ -145,7 +145,12 @@ class EnsureSingleLineProjectStartTag implements TidyTask {
         throw new IllegalArgumentException("The POM has no project node.");
     }
 
-    private String replaceProjectStartTag(String pom, XMLEventReader eventReader, XMLEvent event, String startTag, Collection<QName> additionalProperties)
+    private String replaceProjectStartTag(
+            String pom,
+            XMLEventReader eventReader,
+            XMLEvent event,
+            String startTag,
+            Collection<QName> additionalProperties)
             throws XMLStreamException {
         int start = event.getLocation().getCharacterOffset();
         final Map<QName, String> additionalPropertiesMap;
@@ -176,15 +181,7 @@ class EnsureSingleLineProjectStartTag implements TidyTask {
                 } else {
                     result.append(additionalProperty.getPrefix()).append(':').append(additionalProperty.getLocalPart());
                 }
-                result.append('=')
-                        .append(
-                                StringUtils.quoteAndEscape(
-                                        value,
-                                        '"',
-                                        new char[]{'"', '\\'},
-                                        '\\',
-                                        true)
-                        );
+                result.append('=').append(StringUtils.quoteAndEscape(value, '"', new char[] {'"', '\\'}, '\\', true));
             }
         }
         return result.append('>').append(pom.substring(nextChar)).toString();

--- a/src/main/java/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTag.java
+++ b/src/main/java/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTag.java
@@ -19,42 +19,174 @@ package org.codehaus.mojo.tidy.task;
  * under the License.
  */
 
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.XMLEvent;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.codehaus.plexus.util.StringUtils;
 
 import static org.codehaus.mojo.tidy.task.XMLEventReaderFactory.createEventReaderForPom;
 
 class EnsureSingleLineProjectStartTag implements TidyTask {
     private static final String PROJECT_START_TAG = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" "
             + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
-            + "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\">";
+            + "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\"";
+    
+    private static final Collection<QName> PROJECT_4_0_ATTRIBUTES = Collections.singleton(
+        new QName(null, "child.project.url.inherit.append.path")
+    );
+    
+    private static final Collection<QName> PROJECT_4_1_ATTRIBUTES = Collections.unmodifiableSet(
+            new HashSet<>(
+                    Arrays.asList(
+                            new QName(null, "child.project.url.inherit.append.path"),
+                            new QName(null, "root"),
+                            new QName(null, "preserve.model.version")
+                    ))
+    );
+    
+    private static final String PROJECT_4_1_START_TAG = "<project xmlns=\"http://maven.apache.org/POM/4.1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+            "  xsi:schemaLocation=\"http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd\"";
 
     @Override
     public String tidyPom(String pom, Format format) throws XMLStreamException {
+        final String modelVersion = identifyModelVersion(pom);
+        if ("4.1.0".equals(modelVersion)) {
+            return tidy41Pom(pom);
+        }
+        return tidy40Pom(pom);
+    }
+
+    private String tidy40Pom(String pom) throws XMLStreamException {
         XMLEventReader eventReader = createEventReaderForPom(pom);
         try {
-            return tidyProjectStartTag(pom, eventReader);
+            return tidyProjectStartTag(pom, eventReader, PROJECT_START_TAG, PROJECT_4_0_ATTRIBUTES);
         } finally {
             eventReader.close();
         }
     }
 
-    private String tidyProjectStartTag(String pom, XMLEventReader eventReader) throws XMLStreamException {
+    private String tidy41Pom(String pom) throws XMLStreamException {
+        XMLEventReader eventReader = createEventReaderForPom(pom);
+        try {
+            return tidyProjectStartTag(pom, eventReader, PROJECT_4_1_START_TAG, PROJECT_4_1_ATTRIBUTES);
+        } finally {
+            eventReader.close();
+        }
+    }
+
+    private String identifyModelVersion(String pom) throws XMLStreamException {
+        XMLEventReader eventReader = createEventReaderForPom(pom);
+        try {
+            return identifyModelVersion(eventReader);
+        } finally {
+            eventReader.close();
+        }
+    }
+
+    private String identifyModelVersion(XMLEventReader eventReader) throws XMLStreamException {
+        XMLEvent event = eventReader.nextTag();
+        while (null != event) {
+            if (event.isStartElement()) {
+                if (event.asStartElement().getName().getLocalPart().equals("project")) {
+                    return resolveModelVersion(eventReader);
+                }
+                event = skipNestedContent(eventReader);
+            } else {
+                event = eventReader.nextTag();
+            }
+        }
+        return null;
+    }
+
+    private XMLEvent skipNestedContent(XMLEventReader eventReader) throws XMLStreamException {
+        int nestedSize = 0;
+        XMLEvent xmlEvent = eventReader.nextTag();
+        while (xmlEvent != null && nestedSize >= 0) {
+            if (xmlEvent.isEndElement()) {
+                nestedSize--;
+            } else {
+                nestedSize++;
+            }
+            xmlEvent = eventReader.nextTag();
+        }
+        return xmlEvent;
+    }
+
+    private String resolveModelVersion(XMLEventReader eventReader) throws XMLStreamException {
+        XMLEvent xmlEvent = eventReader.nextTag();
+        while (xmlEvent != null && xmlEvent.isStartElement()) {
+            if (xmlEvent.asStartElement().getName().getLocalPart().equals("modelVersion")) {
+                return eventReader.getElementText();
+            }
+            xmlEvent = skipNestedContent(eventReader);
+        }
+        return null;
+    }
+
+    private String tidyProjectStartTag(String pom, XMLEventReader eventReader, String projectStartTag, Collection<QName> additionalProperties) throws XMLStreamException {
         while (eventReader.hasNext()) {
             XMLEvent event = eventReader.nextEvent();
             if (event.isStartElement()
                     && event.asStartElement().getName().getLocalPart().equals("project")) {
-                return replaceProjectStartTag(pom, eventReader, event);
+                return replaceProjectStartTag(pom, eventReader, event, projectStartTag, additionalProperties);
             }
         }
         throw new IllegalArgumentException("The POM has no project node.");
     }
 
-    private String replaceProjectStartTag(String pom, XMLEventReader eventReader, XMLEvent event)
+    private String replaceProjectStartTag(String pom, XMLEventReader eventReader, XMLEvent event, String startTag, Collection<QName> additionalProperties)
             throws XMLStreamException {
         int start = event.getLocation().getCharacterOffset();
+        final Map<QName, String> additionalPropertiesMap;
+        if (additionalProperties.isEmpty()) {
+            additionalPropertiesMap = Collections.emptyMap();
+        } else {
+            additionalPropertiesMap = new HashMap<>(additionalProperties.size());
+            final Iterator<Attribute> attributeIterator = event.asStartElement().getAttributes();
+            while (attributeIterator.hasNext()) {
+                final Attribute currentAttribute = attributeIterator.next();
+                final QName attributeQualifiedName = currentAttribute.getName();
+                if (additionalProperties.contains(attributeQualifiedName)) {
+                    additionalPropertiesMap.put(attributeQualifiedName, currentAttribute.getValue());
+                }
+            }
+        }
         int nextChar = eventReader.nextEvent().getLocation().getCharacterOffset();
-        return pom.substring(0, start) + PROJECT_START_TAG + pom.substring(nextChar);
+        if (additionalPropertiesMap.isEmpty()) {
+            return pom.substring(0, start) + startTag + ">" + pom.substring(nextChar);
+        }
+        StringBuilder result = new StringBuilder(pom.substring(0, start)).append(startTag);
+        for (QName additionalProperty : additionalProperties) {
+            final String value = additionalPropertiesMap.get(additionalProperty);
+            if (value != null) {
+                result.append(' ');
+                if (additionalProperty.getPrefix().equals(XMLConstants.DEFAULT_NS_PREFIX)) {
+                    result.append(additionalProperty.getLocalPart());
+                } else {
+                    result.append(additionalProperty.getPrefix()).append(':').append(additionalProperty.getLocalPart());
+                }
+                result.append('=')
+                        .append(
+                                StringUtils.quoteAndEscape(
+                                        value,
+                                        '"',
+                                        new char[]{'"', '\\'},
+                                        '\\',
+                                        true)
+                        );
+            }
+        }
+        return result.append('>').append(pom.substring(nextChar)).toString();
     }
 }

--- a/src/test/java/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest.java
+++ b/src/test/java/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest.java
@@ -1,0 +1,38 @@
+package org.codehaus.mojo.tidy.task;
+
+import javax.xml.stream.XMLStreamException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.codehaus.plexus.util.IOUtil;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit test class dedicated to the validation of {@link EnsureSingleLineProjectStartTag}.
+ *
+ * @author Antoine Malliarakis
+ */
+class EnsureSingleLineProjectStartTagTest {
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(
+            strings = {
+                "project-single-line",
+                "project-support-4-1-0-attributes",
+                "project-support-4-1-0-attributes-with-unordered-nodes",
+                "project-support-4-1-0-model-version"
+            })
+    void applyTidying(String name) throws IOException, XMLStreamException {
+        String pom = readPom(name, "pom.xml");
+        String tidyPom = new EnsureSingleLineProjectStartTag().tidyPom(pom, new FormatIdentifier().identifyFormat(pom));
+        assertEquals(readPom(name, "pom-expected.xml"), tidyPom);
+    }
+
+    private String readPom(String test, String filename) throws IOException {
+        InputStream is = getClass().getResourceAsStream(getClass().getSimpleName() + "/" + test + "/" + filename);
+        return IOUtil.toString(is);
+    }
+}

--- a/src/test/java/org/codehaus/mojo/tidy/task/PomTidyTest.java
+++ b/src/test/java/org/codehaus/mojo/tidy/task/PomTidyTest.java
@@ -48,7 +48,8 @@ class PomTidyTest {
                 "pom-with-profiles",
                 "pom-with-reporting",
                 "project-single-line",
-                "project-support-4-1-0-attributes"
+                "project-support-4-1-0-attributes",
+                "project-support-4-1-0-model-version"
             })
     void generatesTidyPom(String name) throws IOException, XMLStreamException {
         String pom = readPom(name, "pom.xml");

--- a/src/test/java/org/codehaus/mojo/tidy/task/PomTidyTest.java
+++ b/src/test/java/org/codehaus/mojo/tidy/task/PomTidyTest.java
@@ -49,6 +49,7 @@ class PomTidyTest {
                 "pom-with-reporting",
                 "project-single-line",
                 "project-support-4-1-0-attributes",
+                "project-support-4-1-0-attributes-with-unordered-nodes",
                 "project-support-4-1-0-model-version"
             })
     void generatesTidyPom(String name) throws IOException, XMLStreamException {

--- a/src/test/java/org/codehaus/mojo/tidy/task/PomTidyTest.java
+++ b/src/test/java/org/codehaus/mojo/tidy/task/PomTidyTest.java
@@ -47,7 +47,8 @@ class PomTidyTest {
                 "pom-with-line-without-indent",
                 "pom-with-profiles",
                 "pom-with-reporting",
-                "project-single-line"
+                "project-single-line",
+                "project-support-4-1-0-attributes"
             })
     void generatesTidyPom(String name) throws IOException, XMLStreamException {
         String pom = readPom(name, "pom.xml");

--- a/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-single-line/pom-expected.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-single-line/pom-expected.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-single-line/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-single-line/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-attributes-with-unordered-nodes/pom-expected.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-attributes-with-unordered-nodes/pom-expected.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd" root="true" preserve.model.version="true" child.project.url.inherit.append.path="true">
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 attributes even though ordering is not satisfied</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <modelVersion>4.1.0</modelVersion>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-attributes-with-unordered-nodes/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-attributes-with-unordered-nodes/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd"
+         root="true"
+         child.project.url.inherit.append.path="true"
+         preserve.model.version="true"
+>
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 attributes even though ordering is not satisfied</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <modelVersion>4.1.0</modelVersion>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-attributes/pom-expected.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-attributes/pom-expected.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd" root="true" preserve.model.version="true" child.project.url.inherit.append.path="true">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 attributes.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-attributes/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-attributes/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd"
+         root="true"
+         child.project.url.inherit.append.path="true"
+         preserve.model.version="true"
+>
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 attributes.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-model-version/pom-expected.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-model-version/pom-expected.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 model version</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-model-version/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/EnsureSingleLineProjectStartTagTest/project-support-4-1-0-model-version/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd"
+>
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 model version</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-attributes-with-unordered-nodes/pom-expected.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-attributes-with-unordered-nodes/pom-expected.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd" root="true" preserve.model.version="true" child.project.url.inherit.append.path="true">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 attributes even though ordering is not satisfied</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-attributes-with-unordered-nodes/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-attributes-with-unordered-nodes/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd"
+         root="true"
+         child.project.url.inherit.append.path="true"
+         preserve.model.version="true"
+>
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 attributes even though ordering is not satisfied</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <modelVersion>4.1.0</modelVersion>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-attributes/pom-expected.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-attributes/pom-expected.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd" root="true" preserve.model.version="true" child.project.url.inherit.append.path="true">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 attributes.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-attributes/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-attributes/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd"
+         root="true"
+         child.project.url.inherit.append.path="true"
+         preserve.model.version="true"
+>
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 attributes.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-model-version/pom-expected.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-model-version/pom-expected.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 model version</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-model-version/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/tidy/task/project-support-4-1-0-model-version/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd"
+>
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.tidy.its</groupId>
+  <artifactId>add-xml-declaration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Test of tidy:pom ensuring project element on a single row in a pom and supports 4.1.0 model version</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+</project>


### PR DESCRIPTION
There were two issues:

1. We didn't take into account the fact that for a `modelVersion` node being set to `4.1.0` one should allow the support of two additional `project` XML attributes: [`root`](https://maven.apache.org/ref/4.0.0-beta-3/maven-model/maven.html#class_project) and [`preserve.model.version`](https://maven.apache.org/ref/4.0.0-beta-3/maven-model/maven.html#class_project)
2. Also there was an issue with an attribute which should have been allowed for 4.0.0 cases and is supported starting from maven 3.6.1: [`child.project.url.inherit.append.path`](https://maven.apache.org/ref/3.6.1/maven-model/maven.html#class_project)

Fixes https://github.com/mojohaus/tidy-maven-plugin/issues/97
Fixes https://github.com/mojohaus/tidy-maven-plugin/issues/106